### PR TITLE
Adapted fuzzy membership function piecemf + creation of ipiecemf and gpiecemf

### DIFF
--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -9,6 +9,9 @@ try:
     from numpy.testing.decorators import skipif
 except AttributeError:
     from numpy.testing.dec import skipif
+except ModuleNotFoundError:
+    from numpy.testing import dec
+    skipif = dec.skipif
 
 import networkx
 import nose
@@ -134,7 +137,7 @@ def test_bad_inputs():
                              'raise an IndexError.')
 
 
-@tst.decorators.skipif(float(networkx.__version__) >= 2.0)
+@skipif(float(networkx.__version__) >= 2.0)
 @nose.with_setup(setup_rule_order)
 def test_rule_order():
     # Make sure rules are exposed in the order needed to solve them
@@ -152,7 +155,7 @@ def test_rule_order():
 
 
 # The assert_raises decorator does not work in Python 2.6
-@tst.decorators.skipif(
+@skipif(
     (sys.version_info < (2, 7)) or (float(networkx.__version__) >= 2.0))
 @nose.with_setup(setup_rule_order)
 def test_unresolvable_rule_order():

--- a/skfuzzy/control/tests/test_ordereddict.py
+++ b/skfuzzy/control/tests/test_ordereddict.py
@@ -22,6 +22,9 @@ try:
     from numpy.testing.decorators import skipif
 except AttributeError:
     from numpy.testing.dec import skipif
+except ModuleNotFoundError:
+    from numpy.testing import dec
+    skipif = dec.skipif
 from _skipclass import skipclassif
 
 

--- a/skfuzzy/image/tests/test_pad.py
+++ b/skfuzzy/image/tests/test_pad.py
@@ -13,6 +13,9 @@ try:
     from numpy.testing.decorators import skipif
 except AttributeError:
     from numpy.testing.dec import skipif
+except ModuleNotFoundError:
+    from numpy.testing import dec
+    skipif = dec.skipif
 from _skipclass import skipclassif
 
 from skfuzzy.image import pad

--- a/skfuzzy/membership/__init__.py
+++ b/skfuzzy/membership/__init__.py
@@ -6,6 +6,8 @@ __all__ = ['dsigmf',
            'gaussmf',
            'gauss2mf',
            'gbellmf',
+           'gpiecemf',
+           'ipiecemf',
            'piecemf',
            'pimf',
            'psigmf',
@@ -15,5 +17,6 @@ __all__ = ['dsigmf',
            'trimf',
            'zmf']
 
-from .generatemf import (dsigmf, gaussmf, gauss2mf, gbellmf, piecemf, pimf,
-                         psigmf, sigmf, smf, trapmf, trimf, zmf)
+from .generatemf import (dsigmf, gaussmf, gauss2mf, gbellmf, gpiecemf,
+                         ipiecemf, piecemf, pimf, psigmf, sigmf, smf, trapmf,
+                         trimf, zmf)

--- a/skfuzzy/membership/generatemf.py
+++ b/skfuzzy/membership/generatemf.py
@@ -172,27 +172,134 @@ def piecemf(x, abc):
                 y = 0,                    min(x) <= x <= a
                 y = b(x - a)/c(b - a),    a <= x <= b
                 y = x/c,                  b <= x <= c
+                y = 1,                    c <= x <= max(x)
     """
     a, b, c = abc
-    if c != x.max():
-        c = x.max()
 
     assert a <= b and b <= c, '`abc` requires a <= b <= c.'
 
-    n = len(x)
-    y = np.zeros(n)
+    y = np.zeros(len(x))
 
-    idx0 = _nearest(x, 0)[0]
-    idxa = _nearest(x, a)[0]
-    idxb = _nearest(x, b)[0]
+    idx = np.logical_and(a <= x, x <= b)
+    y[idx] = (b * (x[idx] - a)) / float(c * (b - a))
 
-    n = np.r_[0:n - idx0]
-    y[idx0 + n] = n / float(c)
-    y[idx0:idxa] = 0
-    m = np.r_[0:idxb - idxa]
-    y[idxa:idxb] = b * m / (float(c) * (b - a))
+    idx = np.logical_and(b < x, x <= c)
+    y[idx] = x[idx] / float(c)
 
-    return y / y.max()
+    idx = x >= c
+    y[idx] = 1
+
+    return y
+
+
+def ipiecemf(x, abc):
+    """
+    Inverse piecewise linear membership function (inverse of piecemf).
+
+    Parameters
+    ----------
+    x : 1d array
+        Independent variable vector.
+    abc : 1d array, length 3
+        Defines the inverse piecewise function. Important: if abc = [a, b, c]
+        then a <= b <= c is REQUIRED!
+
+    Returns
+    -------
+    y : 1d array
+        Inverse piecewise fuzzy membership function for x.
+
+    Notes
+    -----
+    Inverse piecewise definition:
+                y = 1,                    min(x) <= x <= a
+                y = (b + a - x)/b,        a <= x <= b
+                y = a(c - x)/b(c - b),    b <= x <= c
+                y = 0,                    c <= x <= max(x)
+    """
+    a, b, c = abc
+
+    assert a <= b and b <= c, '`abc` requires a <= b <= c.'
+
+    y = np.zeros(len(x))
+
+    idx = x <= a
+    y[idx] = 1
+
+    idx = np.logical_and(a <= x, x <= b)
+    y[idx] = (b + a - x[idx]) / float(b)
+
+    idx = np.logical_and(b < x, x <= c)
+    y[idx] = (a * (c - x[idx])) / float(b * (c - b))
+
+    return y
+
+
+def gpiecemf(x, abc, efg):
+    """
+    General piecewise linear membership function, which combines the
+    functionalities of piecemf and ipiecemf.
+
+    Parameters
+    ----------
+    x : 1d array
+        Independent variable vector.
+    abc : 1d array, length 3
+        Defines the piecewise function. Important: if abc = [a, b, c] then
+        a <= b <= c is REQUIRED!
+    efg : 1d array, length 3
+        Defines the inverse piecewise function. Important: if efg = [e, f, g]
+        then e <= f <= g is REQUIRED! In addition, c <= e or g <= a is also
+        REQUIRED!
+
+    Returns
+    -------
+    y : 1d array
+        General piecewise fuzzy membership function for x.
+
+    Notes
+    -----
+    General piecewise definition:
+        if c<=e:
+                y = 0,                    min(x) <= x <= a
+                y = b(x - a)/c(b - a),    a <= x <= b
+                y = x/c,                  b <= x <= c
+                y = 1,                    c <= x <= e
+                y = (f + e - x)/f,        e <= x <= f
+                y = e(g - x)/f(g - f),    f <= x <= g
+                y = 0,                    g <= x <= max(x)
+        if g<=a:
+                y = 1,                    min(x) <= x <= e
+                y = (f + e - x)/f,        e <= x <= f
+                y = e(g - x)/f(g - f),    f <= x <= g
+                y = 0,                    g <= x <= a
+                y = b(x - a)/c(b - a),    a <= x <= b
+                y = x/c,                  b <= x <= c
+                y = 1,                    c <= x <= max(x)
+    """
+    a, b, c = abc
+    e, f, g = efg
+
+    assert c <= e or g <= a, 'c <= e or g <= a required.'
+
+    y_piecemf = piecemf(x, abc)
+    y_ipiecemf = ipiecemf(x, efg)
+    if c <= e:
+        y = np.ones(len(x))
+        idx = x <= c
+        y[idx] = y_piecemf[idx]
+
+        idx = x >= e
+        y[idx] = y_ipiecemf[idx]
+    elif g <= a:
+        y = np.zeros(len(x))
+        idx = x <= g
+        y[idx] = y_ipiecemf[idx]
+
+        idx = x >= a
+        y[idx] = y_piecemf[idx]
+
+    return y
 
 
 def pimf(x, a, b, c, d):

--- a/skfuzzy/membership/tests/test_generatemf.py
+++ b/skfuzzy/membership/tests/test_generatemf.py
@@ -1,7 +1,8 @@
 import numpy as np
 from numpy.testing import assert_allclose
-from skfuzzy.membership import (gaussmf, gauss2mf, gbellmf, piecemf, pimf,
-                                psigmf, sigmf, smf, trapmf, trimf, zmf)
+from skfuzzy.membership import (gaussmf, gauss2mf, gbellmf, gpiecemf, ipiecemf,
+                                piecemf, pimf, psigmf, sigmf, smf, trapmf,
+                                trimf, zmf)
 
 
 def test_gaussmf():
@@ -28,13 +29,53 @@ def test_gbellmf():
     assert_allclose(test, expected)
 
 
-def test_piecemf():
+def test_piecemf_c_equal_to_max_x():
     x = np.arange(0, 2.1, 0.1)
     expected = np.r_[0.,    0.,   0.,  0.,   0.,  0.,   0.,  0.,   0.,
-                     0.,    0., 0.25, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85,
+                     0.,    0., 0.25, 0.5, 0.65, 0.7, 0.75, 0.8, 0.85,
                      0.9, 0.95,   1.]
     test = piecemf(x, [1, 1.25, 2])
     assert_allclose(test, expected)
+
+
+def test_piecemf_c_smaller_than_max_x():
+    x = np.arange(0, 2.6, 0.1)
+    expected = np.r_[0.,    0.,   0.,  0.,   0.,  0.,   0.,  0.,   0.,
+                     0.,    0., 0.25, 0.5, 0.65, 0.7, 0.75, 0.8, 0.85,
+                     0.9, 0.95,   1.,  1.,   1.,  1.,   1.,  1.]
+    test = piecemf(x, [1, 1.25, 2])
+    assert_allclose(test, expected)
+
+
+def test_ipiecemf():
+    x = np.arange(0, 2.6, 0.1)
+    expected = np.r_[1.,     1.,   1.,   1.,   1.,   1.,   1.,   1.,   1.,
+                     1.,     1., 0.92, 0.84, 0.75, 0.65, 0.55, 0.45, 0.35,
+                     0.25, 0.15, 0.05,   0.,   0.,   0.,   0.,   0.]
+    test = ipiecemf(x, [1, 1.25, 2.05])
+    assert_allclose(test, expected)
+
+
+def test_gpiecemf_c_smaller_than_e():
+    x = np.arange(0, 4.1, 0.1)
+    expected = np.r_[0.,    0.,   0.,  0.,   0.,  0.,   0.,  0.,   0.,
+                     0.,    0., 0.25, 0.5, 0.65, 0.7, 0.75, 0.8, 0.85,
+                     0.9, 0.95,   1.,  1.,   1.,  1.,   1.,  1., 0.963636,
+                     0.927272, 0.852272, 0.738636, 0.625, 0.511363, 0.397727,
+                     0.284090, 0.170454, 0.056818, 0., 0., 0., 0., 0.]
+    test = gpiecemf(x, [1, 1.25, 2], [2.5, 2.75, 3.55])
+    assert_allclose(test, expected, rtol=1e-5)
+
+
+def test_gpiecemf_g_smaller_than_a():
+    x = np.arange(0, 4.1, 0.1)
+    expected = np.r_[1.,     1.,   1.,   1.,   1.,   1.,   1.,   1.,   1.,
+                     1.,     1., 0.92, 0.84, 0.75, 0.65, 0.55, 0.45, 0.35,
+                     0.25, 0.15, 0.05,   0.,   0.,   0.,   0.,   0., 0.314285,
+                     0.628571, 0.8, 0.828571, 0.857142, 0.885714, 0.914285,
+                     0.942857, 0.971428, 1., 1., 1., 1., 1., 1.]
+    test = gpiecemf(x, [2.5, 2.75, 3.5], [1, 1.25, 2.05])
+    assert_allclose(test, expected, rtol=1e-5)
 
 
 def test_pimf_smf_zmf():


### PR DESCRIPTION
This PR is the same as https://github.com/scikit-fuzzy/scikit-fuzzy/pull/264 and includes the following changes to the repo:

1. Fixed bugs related to 'ENV=python 3.6 numpy' (Travis CI build).

2. The piecemf() membership function is adapted in such a way that y is equal to 1 when x >= c instead of overwriting c by max(x). An additional test (test_piecemf_c_smaller_than_max_x()) was created to test this new functionality, while the original test_piecemf() was renamed to test_piecemf_c_equal_to_max_x().

3. Fixed a bug in the piecemf() membership function: 
        As stated in the description of piecemf(), the membership function should satisfy following equation (now extended with y=1 when c <= x <= max(x)): 
                       y = 0,                  min(x) <= x <= a
                       y = b(x - a)/c(b - a),    a <= x <= b
                       y = x/c,                       b <= x <= c
        but this was not the case. More specifically, if we consider test_piecemf() with a =1, b= 1.25 and c=2, we would expect that             y(x=1.2) = b(x - a)/c(b - a) = 1.25*(1.2 - 1)/(2*(1.25 - 1)) = 0.5, 
but the function generated 
y(x=1.2) = x/c = 1.25/2 = 0.6 
instead. To fix this, the piecemf()-function has been rewritten in a more clean and understandable way and the related tests have been updated.

4. Addition of fuzzy membership function ipiecemf() (i = inverse), which is similar to piecemf(), but this function goes from 1 to 0 in a piecewise linear way instead of from 0 to 1 in a piecewise linear way. Also added test_ipiecemf() to test its functionality.

5. Addition of fuzzy membership function gpiecemf() (g = generalized, similar to “gbellmf” that stands for “generalized Bell membership function”), which combines piecemf() and ipiecemf() in one function that goes piecewise linear from 0 to 1 and then back from 1 to 0 or the other way around, i.e. piecewise linear from 1 to 0 and then back from 0 to 1. Also added test_gpiecemf_c_smaller_than_e() and test_gpiecemf_g_smaller_than_a() to test both cases.