### PR TITLE
Creation new class LogStateControlSystemSimulation in skfuzzy/control/controlsystem.py + updated print_state() accordingly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@
 language: python
 
 
-#  The Travis python is set to 3.2 for all builds, since we use the default python for the 3.2 build and the anaconda python otherwise
+#  The Travis python is set to 3.6 for all builds, since we use the default python for the 3.6 build and the anaconda python otherwise
 python:
     - 3.6
 
@@ -37,6 +37,9 @@ before_install:
         travis_retry conda install pyqt;
       else
         travis_retry conda install pillow;
+      fi
+    - if [[ $ENV == python=2.7* ]]; then
+        travis_retry conda install mock;
       fi
     - travis_retry pip install coveralls
 

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -501,7 +501,7 @@ class ControlSystemSimulation(object):
         print(" Antecedents ")
         print("=============")
         for v in self.ctrl.antecedents:
-            print("{0:<35} = {1}".format(v, v.input[self]))
+            print("{0:<35} = {1}".format(str(v), v.input[self]))
             for term in v.terms.values():
                 print("  - {0:<32}: {1}".format(term.label,
                                                 term.membership_value[self]))
@@ -520,13 +520,13 @@ class ControlSystemSimulation(object):
                 assert isinstance(term, Term)
                 print("  - {0:<55}: {1}".format(term.full_label,
                                                 term.membership_value[self]))
-            print("    {0:>54} = {1}".format(r.antecedent,
+            print("    {0:>54} = {1}".format(str(r.antecedent),
                                              r.aggregate_firing[self]))
 
             print("  Activation (THEN-clause):")
             for c in r.consequent:
                 assert isinstance(c, WeightedTerm)
-                print("    {0:>54} : {1}".format(c,
+                print("    {0:>54} : {1}".format(str(c),
                                                  c.activation[self]))
             print("")
         print("")
@@ -536,7 +536,7 @@ class ControlSystemSimulation(object):
         print("==============================")
         for c in self.ctrl.consequents:
             print("{0:<36} = {1}".format(
-                c, CrispValueCalculator(c, self).defuzz()))
+                str(c), CrispValueCalculator(c, self).defuzz()))
 
             for term in c.terms.values():
                 print("  %s:" % term.label)
@@ -545,8 +545,8 @@ class ControlSystemSimulation(object):
                         continue
                     print("    {0:>32} : {1}".format(rule_number[cut_rule],
                                                      cut_value))
-                accu = "Accumulate using %s" % c.accumulation_method.func_name
-                print("    {0:>32} : {1}".format(accu,
+                accu = "Accumulate using %s" % c.accumulation_method.__name__
+                print("    {0:>32} : {1}".format(str(accu),
                                                  term.membership_value[self]))
             print("")
 

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -502,9 +502,11 @@ class ControlSystemSimulation(object):
         print(" Antecedents ")
         print("=============")
         for v in log_state.antecedents:
-            print("{0:<35} = {1}".format(str(v), log_state.dict_antecedents_input()[str(v)]))
+            print("{0:<35} = {1}".format(str(v), log_state.
+                                         dict_antecedents_input()[str(v)]))
             for term_label, term_membership_value \
-                    in log_state.dict_antecedents_membership_values()[str(v)].items():
+                in log_state.dict_antecedents_membership_values()[str(v)].\
+                    items():
                 print("  - {0:<32}: {1}".format(term_label,
                                                 term_membership_value))
         print("")
@@ -524,21 +526,26 @@ class ControlSystemSimulation(object):
             print("RULE #%d:\n  %s\n" % (rn, r))
 
             print("  Aggregation (IF-clause):")
-            for cnt in range(len(log_state.dict_rules_aggregation_if_membership_values()[rule_number[r]])):
+            for cnt in range(len(
+                log_state.dict_rules_aggregation_if_membership_values()[
+                    rule_number[r]])):
 
                 for term_full_label, term_membership_value in \
-                        log_state.dict_rules_aggregation_if_membership_values()[rule_number[r]][cnt].items():
+                        log_state.dict_rules_aggregation_if_membership_values()[
+                            rule_number[r]][cnt].items():
                     print("  - {0:<55}: {1}".format(term_full_label,
                                                     term_membership_value))
 
             for antecedent, aggregate_firing in \
-                    log_state.dict_rules_aggregation_if_aggregate_firing()[rule_number[r]].items():
+                    log_state.dict_rules_aggregation_if_aggregate_firing()[
+                        rule_number[r]].items():
                 print("    {0:>54} = {1}".format(antecedent, aggregate_firing))
 
             print("  Activation (THEN-clause):")
 
             for consequent, activation in \
-                    log_state.dict_rules_activation_then()[rule_number[r]].items():
+                    log_state.dict_rules_activation_then()[
+                        rule_number[r]].items():
                 for c in r.consequent:
                     assert isinstance(c, WeightedTerm)
                 print("    {0:>54} : {1}".format(consequent, activation))
@@ -570,16 +577,22 @@ class ControlSystemSimulation(object):
         print("==============================")
         for c in log_state.consequents:
             print("{0:<36} = {1}".format(
-                str(c), log_state.dict_consequents_crispvalue()[c]))
+                str(c), log_state.dict_consequents_crisp_value()[c]))
 
-            for term_label, dict_cut_rules_values in log_state.dict_consequents_terms_cut_rules_and_values()[c].items():
+            for term_label, dict_cut_rules_values in \
+                log_state.dict_consequents_terms_cut_rules_and_values()[c]\
+                    .items():
                 print("  %s:" % term_label)
-                for rule_number_cut_rule, cut_value in dict_cut_rules_values:
+                for rule_number_cut_rule, cut_value \
+                    in dict_cut_rules_values.items():
                     print("    {0:>32} : {1}".format(rule_number_cut_rule,
                                                      cut_value))
                 for accu, term_membership_value in \
-                        log_state.dict_consequents_terms_accumulation_membership_value()[c][term_label].items():
-                    print("    {0:>32} : {1}".format(accu, term_membership_value))
+                    log_state.\
+                        dict_consequents_terms_accumulation_membership_value()[
+                        c][term_label].items():
+                    print("    {0:>32} : {1}".
+                          format(accu, term_membership_value))
             print("")
         # for c in self.ctrl.consequents:
         #     print("{0:<36} = {1}".format(
@@ -611,7 +624,8 @@ class LogStateControlSystemSimulation(object):
     def __init__(self, sim):
         """
         Initialization method for LogStateControlSystemSimulation.
-        """ + '\n'.join(LogStateControlSystemSimulation.__doc__.split('\n')[1:])
+        """ + '\n'.join(LogStateControlSystemSimulation.__doc__.split('\n'
+                                                                      )[1:])
         assert isinstance(sim, ControlSystemSimulation)
         self.sim = sim
         if next(self.sim.ctrl.consequents).output[self.sim] is None:
@@ -622,7 +636,8 @@ class LogStateControlSystemSimulation(object):
 
     def dict_antecedents_input(self):
         """
-        Returns dictionary with the antecedents of self.sim as keys and their input as values.
+        Returns dictionary with the antecedents of self.sim as keys
+        and their input as values.
         """
         dict_antecedents = {}
         for v in self.sim.ctrl.antecedents:
@@ -631,19 +646,24 @@ class LogStateControlSystemSimulation(object):
 
     def dict_antecedents_membership_values(self):
         """
-        Returns dictionary with the antecedents of self.sim as keys and dictionaries as values.
-        Every value-dictionary contains the label of every term in terms.values() linked to the antecedent
-        in consideration with the corresponding membership_value determined by its input value.
+        Returns dictionary with the antecedents of self.sim
+        as keys and dictionaries as values.
+        Every value-dictionary contains the label of every term
+        in terms.values() linked to the antecedent
+        in consideration with the corresponding membership_value
+        determined by its input value.
         """
         dict_antecedents_membership_values = {}
         for v in self.sim.ctrl.antecedents:
-            dict_antecedents_membership_values[str(v)] = {term.label: term.membership_value[self.sim]
-                                                          for term in v.terms.values()}
+            dict_antecedents_membership_values[str(v)] = \
+                {term.label: term.membership_value[self.sim]
+                 for term in v.terms.values()}
         return dict_antecedents_membership_values
 
     def dict_rules(self):
         """
-        Returns dictionary with the rule_number of self.sim.ctrl.rules as keys and the rules as values.
+        Returns dictionary with the rule_number of self.sim.ctrl.rules
+        as keys and the rules as values.
         """
         dict_rules = {}
         rule_number = {}
@@ -655,8 +675,10 @@ class LogStateControlSystemSimulation(object):
 
     def dict_rules_aggregation_if_membership_values(self):
         """
-        Returns dictionary with the rule_number of self.sim.ctrl.rules as keys and lists of dictionaries as values.
-        Every value-dictionary in the list contains the full_label and the corresponding membership_value
+        Returns dictionary with the rule_number of self.sim.ctrl.rules
+        as keys and lists of dictionaries as values.
+        Every value-dictionary in the list contains the full_label
+        and the corresponding membership_value
         of one term in antecedent_term linked to the rule in consideration.
         """
         dict_rules_aggregation_if_membership_values = {}
@@ -667,13 +689,16 @@ class LogStateControlSystemSimulation(object):
             for term in r.antecedent_terms:
                 assert isinstance(term, Term)
             dict_rules_aggregation_if_membership_values[rule_number[r]] = \
-                [{term.full_label: term.membership_value[self.sim]} for term in r.antecedent_terms]
+                [{term.full_label: term.membership_value[self.sim]}
+                 for term in r.antecedent_terms]
         return dict_rules_aggregation_if_membership_values
 
     def dict_rules_aggregation_if_aggregate_firing(self):
         """
-        Returns dictionary with the rule_number of self.sim.ctrl.rules as keys and dictionaries as values.
-        Every value-dictionary contains the antecedent and the corresponding aggregate_firing of the rule
+        Returns dictionary with the rule_number of self.sim.ctrl.rules
+        as keys and dictionaries as values.
+        Every value-dictionary contains the antecedent
+        and the corresponding aggregate_firing of the rule
         in consideration .
         """
         dict_rules_aggregation_if_aggregate_firing = {}
@@ -689,8 +714,10 @@ class LogStateControlSystemSimulation(object):
 
     def dict_rules_activation_then(self):
         """
-        Returns dictionary with the rule_number of self.sim.ctrl.rules as keys and dictionaries as values.
-        Every value-dictionary contains the consequents and the corresponding activation of the rule
+        Returns dictionary with the rule_number of self.sim.ctrl.rules
+        as keys and dictionaries as values.
+        Every value-dictionary contains the consequents
+        and the corresponding activation of the rule
         in consideration .
         """
         dict_rules_activation_then = {}
@@ -704,22 +731,27 @@ class LogStateControlSystemSimulation(object):
                 {str(c): c.activation[self.sim] for c in r.consequent}
         return dict_rules_activation_then
 
-    def dict_consequents_crispvalue(self):
+    def dict_consequents_crisp_value(self):
         """
-        Returns dictionary with the consequent of self.sim.ctrl.consequents as keys and the corresponding
+        Returns dictionary with the consequent of self.sim.ctrl.consequents
+        as keys and the corresponding
         crisp values as values.
         """
-        dict_consequents_crispvalue = {}
+        dict_consequents_crisp_value = {}
         for c in self.sim.ctrl.consequents:
-            dict_consequents_crispvalue[c] = CrispValueCalculator(c, self.sim).defuzz()
-        return dict_consequents_crispvalue
+            dict_consequents_crisp_value[c] = \
+                CrispValueCalculator(c, self.sim).defuzz()
+        return dict_consequents_crisp_value
 
     def dict_consequents_terms_cut_rules_and_values(self):
         """
-        Returns dictionary with the consequent c of self.sim.ctrl.consequents as keys and dictionaries as values.
-        Every value-dictionary contains the term.label of a term in c.terms.values() as key
-        and a list of dictionaries as values. Every dictionary
-        from this list of dictionaries contains a rule_number and cut_value of term.cuts[self.sim].items().
+        Returns dictionary with the consequent c of self.sim.ctrl.consequents
+        as keys and dictionaries as values.
+        Every value-dictionary contains the term.label
+        of a term in c.terms.values() as key
+        and a list of dictionaries as values.
+        Every dictionary from this list of dictionaries contains a rule_number
+        and cut_value of term.cuts[self.sim].items().
         """
         dict_consequents_terms_cut_rules_and_values = {}
         rule_number = {}
@@ -731,17 +763,23 @@ class LogStateControlSystemSimulation(object):
             for term in c.terms.values():
                 dict_consequents_terms_cut_rules_and_values[c][term.label] = {}
                 for cut_rule, cut_value in term.cuts[self.sim].items():
-                    if cut_rule not in rule_number.keys():
+                    output_cut_rule = 'output[' + cut_rule.split()[1] + ']'
+                    if output_cut_rule not in str(rule_number.keys()):
                         continue
-                    dict_consequents_terms_cut_rules_and_values[c][term.label][rule_number[cut_rule]] = cut_value
+                    key_cut_rule = [key for key in rule_number.keys()
+                                    if output_cut_rule in str(key)][0]
+                    dict_consequents_terms_cut_rules_and_values[c][term.label][
+                        rule_number[key_cut_rule]] = cut_value
         return dict_consequents_terms_cut_rules_and_values
 
     def dict_consequents_terms_accumulation_membership_value(self):
         """
-        Returns dictionary with the consequent c of self.sim.ctrl.consequents as keys and dictionaries as values.
-        Every value-dictionary contains the term.label of a term in c.terms.values() as key
-        and a dictionary as values. This dictionary contains information about the accumulation method of the consequent
-        and the corresponding membership_value of the term.
+        Returns dictionary with the consequent c of
+        self.sim.ctrl.consequents as keys and dictionaries as values.
+        Every value-dictionary contains the term.label
+        of a term in c.terms.values() as key and a dictionary as values.
+        This dictionary contains information about the accumulation method
+        of the consequent and the corresponding membership_value of the term.
         """
         dict_consequents_terms_accumulation_membership_value = {}
         rule_number = {}
@@ -752,8 +790,8 @@ class LogStateControlSystemSimulation(object):
             dict_consequents_terms_accumulation_membership_value[c] = {}
             for term in c.terms.values():
                 accu = "Accumulate using %s" % c.accumulation_method.__name__
-                dict_consequents_terms_accumulation_membership_value[c][term.label] = \
-                    {accu: term.membership_value[self.sim]}
+                dict_consequents_terms_accumulation_membership_value[c][
+                    term.label] = {accu: term.membership_value[self.sim]}
         return dict_consequents_terms_accumulation_membership_value
 
 
@@ -881,7 +919,7 @@ class CrispValueCalculator(object):
 
         new_universe = np.union1d(self.var.universe, new_values)
 
-        # Initilize membership
+        # Initialize membership
         output_mf = np.zeros_like(new_universe, dtype=np.float64)
 
         # Build output membership function

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -550,6 +550,24 @@ class ControlSystemSimulation(object):
                                                  term.membership_value[self]))
             print("")
 
+    def serialize(self):
+        """
+        Serialize the info about the inner workings of a ControlSystemSimulation to a dictionary (instead of printing
+        this info by the use of print_state()).
+        """
+        if next(self.ctrl.consequents).output[self] is None:
+            raise ValueError("Call compute method first.")
+
+        inner_workings = dict()
+        inner_workings['Antecedents'] = []
+        for v in self.ctrl.antecedents:
+            inner_workings['Antecedents'].append({str(v)+' - input': str(v.input[self])})
+            inner_workings['Antecedents'].append({
+                str(v)+' - membership_value': {term.label: term.membership_value[self] for term in v.terms.values()}
+            })
+
+        return inner_workings
+
 
 class CrispValueCalculator(object):
     """

--- a/skfuzzy/control/controlsystem.py
+++ b/skfuzzy/control/controlsystem.py
@@ -437,7 +437,7 @@ class ControlSystemSimulation(object):
         """
         Reset the simulation.
 
-        Cear memory by removing all inputs, outputs, and intermediate values.
+        Clear memory by removing all inputs, outputs, and intermediate values.
         """
         self._reset_simulation()
 

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -583,7 +583,8 @@ def test_print_state_for_complex_system(mock_stdout):
     sim.reset()
 
 
-def test_serialize():
+def test_log_state():
+    # TO BE REMOVED LATER!
     # A much more complex system, run multiple times & with array inputs
     universe = np.linspace(-2, 2, 5)
     error = ctrl.Antecedent(universe, 'error')
@@ -652,8 +653,11 @@ def test_serialize():
             sim.compute()
             z[i, j] = sim.output['output']
 
-    dict = sim.serialize()
-    print(dict)
+    # dict = sim.log_state()
+    # sim.log_state_2()
+    # print(dict['Intermediaries and Conquests'])
+    sim.print_state()
+    # print(dict)
     sim.reset()
 
 

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -583,8 +583,7 @@ def test_print_state_for_complex_system(mock_stdout):
     sim.reset()
 
 
-def test_log_state():
-    # TO BE REMOVED LATER!
+def test_print_state(print_state=False):
     # A much more complex system, run multiple times & with array inputs
     universe = np.linspace(-2, 2, 5)
     error = ctrl.Antecedent(universe, 'error')
@@ -652,12 +651,8 @@ def test_log_state():
             sim.input['delta'] = y[i, j]
             sim.compute()
             z[i, j] = sim.output['output']
-
-    # dict = sim.log_state()
-    # sim.log_state_2()
-    # print(dict['Intermediaries and Conquests'])
-    sim.print_state()
-    # print(dict)
+    if print_state:
+        sim.print_state()
     sim.reset()
 
 

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -505,7 +505,7 @@ def test_print_state_for_complex_system(mock_stdout):
     # rule 3:  IF e = SN AND delta = SN THEN output = LP
     # rule 4:  IF e = LP OR  delta = LP THEN output = LN
 
-    rule0 = ctrl.Rule(antecedent=((error['nb'] & delta['nb']) | # This combination, or...
+    rule0 = ctrl.Rule(antecedent=((error['nb'] & delta['nb']) |
                                   (error['ns'] & delta['nb']) |
                                   (error['nb'] & delta['ns'])),
                       consequent=output['nb'], label='rule nb')
@@ -566,7 +566,8 @@ def test_print_state_for_complex_system(mock_stdout):
     # Rules testing
     assert 'Rules' in mock_stdout.getvalue()
     assert 'RULE #0:' in mock_stdout.getvalue()
-    assert 'IF ((error[nb] AND delta[nb]) OR (error[ns] AND delta[nb])) OR (error[nb] AND delta[ns]) THEN output[nb]' \
+    assert 'IF ((error[nb] AND delta[nb]) OR (error[ns] AND delta[nb])) ' + \
+           'OR (error[nb] AND delta[ns]) THEN output[nb]' \
            in mock_stdout.getvalue()
     assert 'Aggregation (IF-clause):' in mock_stdout.getvalue()
     assert 'Activation (THEN-clause):' in mock_stdout.getvalue()
@@ -601,7 +602,7 @@ def test_print_state(print_state=False):
     # rule 3:  IF e = SN AND delta = SN THEN output = LP
     # rule 4:  IF e = LP OR  delta = LP THEN output = LN
 
-    rule0 = ctrl.Rule(antecedent=((error['nb'] & delta['nb']) | # This combination, or...
+    rule0 = ctrl.Rule(antecedent=((error['nb'] & delta['nb']) |
                                   (error['ns'] & delta['nb']) |
                                   (error['nb'] & delta['ns'])),
                       consequent=output['nb'], label='rule nb')

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -583,5 +583,79 @@ def test_print_state_for_complex_system(mock_stdout):
     sim.reset()
 
 
+def test_serialize():
+    # A much more complex system, run multiple times & with array inputs
+    universe = np.linspace(-2, 2, 5)
+    error = ctrl.Antecedent(universe, 'error')
+    delta = ctrl.Antecedent(universe, 'delta')
+    output = ctrl.Consequent(universe, 'output')
+
+    names = ['nb', 'ns', 'ze', 'ps', 'pb']
+    error.automf(names=names)
+    delta.automf(names=names)
+    output.automf(names=names)
+
+    # The rulebase:
+    # rule 1:  IF e = ZE AND delta = ZE THEN output = ZE
+    # rule 2:  IF e = ZE AND delta = SP THEN output = SN
+    # rule 3:  IF e = SN AND delta = SN THEN output = LP
+    # rule 4:  IF e = LP OR  delta = LP THEN output = LN
+
+    rule0 = ctrl.Rule(antecedent=((error['nb'] & delta['nb']) | # This combination, or...
+                                  (error['ns'] & delta['nb']) |
+                                  (error['nb'] & delta['ns'])),
+                      consequent=output['nb'], label='rule nb')
+
+    rule1 = ctrl.Rule(antecedent=((error['nb'] & delta['ze']) |
+                                  (error['nb'] & delta['ps']) |
+                                  (error['ns'] & delta['ns']) |
+                                  (error['ns'] & delta['ze']) |
+                                  (error['ze'] & delta['ns']) |
+                                  (error['ze'] & delta['nb']) |
+                                  (error['ps'] & delta['nb'])),
+                      consequent=output['ns'], label='rule ns')
+
+    rule2 = ctrl.Rule(antecedent=((error['nb'] & delta['pb']) |
+                                  (error['ns'] & delta['ps']) |
+                                  (error['ze'] & delta['ze']) |
+                                  (error['ps'] & delta['ns']) |
+                                  (error['pb'] & delta['nb'])),
+                      consequent=output['ze'], label='rule ze')
+
+    rule3 = ctrl.Rule(antecedent=((error['ns'] & delta['pb']) |
+                                  (error['ze'] & delta['pb']) |
+                                  (error['ze'] & delta['ps']) |
+                                  (error['ps'] & delta['ps']) |
+                                  (error['ps'] & delta['ze']) |
+                                  (error['pb'] & delta['ze']) |
+                                  (error['pb'] & delta['ns'])),
+                      consequent=output['ps'], label='rule ps')
+
+    rule4 = ctrl.Rule(antecedent=((error['ps'] & delta['pb']) |
+                                  (error['pb'] & delta['pb']) |
+                                  (error['pb'] & delta['ps'])),
+                      consequent=output['pb'], label='rule pb')
+
+    system = ctrl.ControlSystem(rules=[rule0, rule1, rule2, rule3, rule4])
+
+    sim = ctrl.ControlSystemSimulation(system, flush_after_run=21 * 21 + 1)
+
+    upsampled = np.linspace(-2, 2, 21)
+    x, y = np.meshgrid(upsampled, upsampled)
+    z = np.zeros_like(x)
+
+    # Loop through the system 21*21 times to collect the control surface
+    for i in range(21):
+        for j in range(21):
+            sim.input['error'] = x[i, j]
+            sim.input['delta'] = y[i, j]
+            sim.compute()
+            z[i, j] = sim.output['output']
+
+    dict = sim.serialize()
+    print(dict)
+    sim.reset()
+
+
 if __name__ == '__main__':
     tst.run_module_suite()

--- a/skfuzzy/control/tests/test_controlsystem.py
+++ b/skfuzzy/control/tests/test_controlsystem.py
@@ -9,9 +9,24 @@ try:
     from numpy.testing.decorators import skipif
 except AttributeError:
     from numpy.testing.dec import skipif
+except ModuleNotFoundError:
+    from numpy.testing import dec
+    skipif = dec.skipif
 
-from io import StringIO
-from unittest.mock import patch
+if sys.version_info[0] < 3:
+    from io import BytesIO as StringIO
+else:
+    from io import StringIO
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import patch
+    run_test_print_state_for_complex_system = True
+else:
+    try:
+        from mock import patch
+        run_test_print_state_for_complex_system = True
+    except ImportError:
+        run_test_print_state_for_complex_system = False
 
 import networkx
 import nose
@@ -137,7 +152,7 @@ def test_bad_inputs():
                              'raise an IndexError.')
 
 
-@tst.decorators.skipif(float(networkx.__version__) >= 2.0)
+@skipif(float(networkx.__version__) >= 2.0)
 @nose.with_setup(setup_rule_order)
 def test_rule_order():
     # Make sure rules are exposed in the order needed to solve them
@@ -155,7 +170,7 @@ def test_rule_order():
 
 
 # The assert_raises decorator does not work in Python 2.6
-@tst.decorators.skipif(
+@skipif(
     (sys.version_info < (2, 7)) or (float(networkx.__version__) >= 2.0))
 @nose.with_setup(setup_rule_order)
 def test_unresolvable_rule_order():
@@ -486,102 +501,104 @@ def test_complex_system():
     np.testing.assert_allclose(z1, expected)
 
 
-@patch('sys.stdout', new_callable=StringIO)
-def test_print_state_for_complex_system(mock_stdout):
-    # A much more complex system, run multiple times & with array inputs
-    universe = np.linspace(-2, 2, 5)
-    error = ctrl.Antecedent(universe, 'error')
-    delta = ctrl.Antecedent(universe, 'delta')
-    output = ctrl.Consequent(universe, 'output')
+if run_test_print_state_for_complex_system:
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_state_for_complex_system(mock_stdout):
+        # A much more complex system, run multiple times & with array inputs
+        universe = np.linspace(-2, 2, 5)
+        error = ctrl.Antecedent(universe, 'error')
+        delta = ctrl.Antecedent(universe, 'delta')
+        output = ctrl.Consequent(universe, 'output')
 
-    names = ['nb', 'ns', 'ze', 'ps', 'pb']
-    error.automf(names=names)
-    delta.automf(names=names)
-    output.automf(names=names)
+        names = ['nb', 'ns', 'ze', 'ps', 'pb']
+        error.automf(names=names)
+        delta.automf(names=names)
+        output.automf(names=names)
 
-    # The rulebase:
-    # rule 1:  IF e = ZE AND delta = ZE THEN output = ZE
-    # rule 2:  IF e = ZE AND delta = SP THEN output = SN
-    # rule 3:  IF e = SN AND delta = SN THEN output = LP
-    # rule 4:  IF e = LP OR  delta = LP THEN output = LN
+        # The rulebase:
+        # rule 1:  IF e = ZE AND delta = ZE THEN output = ZE
+        # rule 2:  IF e = ZE AND delta = SP THEN output = SN
+        # rule 3:  IF e = SN AND delta = SN THEN output = LP
+        # rule 4:  IF e = LP OR  delta = LP THEN output = LN
 
-    rule0 = ctrl.Rule(antecedent=((error['nb'] & delta['nb']) |
-                                  (error['ns'] & delta['nb']) |
-                                  (error['nb'] & delta['ns'])),
-                      consequent=output['nb'], label='rule nb')
+        rule0 = ctrl.Rule(antecedent=((error['nb'] & delta['nb']) |
+                                      (error['ns'] & delta['nb']) |
+                                      (error['nb'] & delta['ns'])),
+                          consequent=output['nb'], label='rule nb')
 
-    rule1 = ctrl.Rule(antecedent=((error['nb'] & delta['ze']) |
-                                  (error['nb'] & delta['ps']) |
-                                  (error['ns'] & delta['ns']) |
-                                  (error['ns'] & delta['ze']) |
-                                  (error['ze'] & delta['ns']) |
-                                  (error['ze'] & delta['nb']) |
-                                  (error['ps'] & delta['nb'])),
-                      consequent=output['ns'], label='rule ns')
+        rule1 = ctrl.Rule(antecedent=((error['nb'] & delta['ze']) |
+                                      (error['nb'] & delta['ps']) |
+                                      (error['ns'] & delta['ns']) |
+                                      (error['ns'] & delta['ze']) |
+                                      (error['ze'] & delta['ns']) |
+                                      (error['ze'] & delta['nb']) |
+                                      (error['ps'] & delta['nb'])),
+                          consequent=output['ns'], label='rule ns')
 
-    rule2 = ctrl.Rule(antecedent=((error['nb'] & delta['pb']) |
-                                  (error['ns'] & delta['ps']) |
-                                  (error['ze'] & delta['ze']) |
-                                  (error['ps'] & delta['ns']) |
-                                  (error['pb'] & delta['nb'])),
-                      consequent=output['ze'], label='rule ze')
+        rule2 = ctrl.Rule(antecedent=((error['nb'] & delta['pb']) |
+                                      (error['ns'] & delta['ps']) |
+                                      (error['ze'] & delta['ze']) |
+                                      (error['ps'] & delta['ns']) |
+                                      (error['pb'] & delta['nb'])),
+                          consequent=output['ze'], label='rule ze')
 
-    rule3 = ctrl.Rule(antecedent=((error['ns'] & delta['pb']) |
-                                  (error['ze'] & delta['pb']) |
-                                  (error['ze'] & delta['ps']) |
-                                  (error['ps'] & delta['ps']) |
-                                  (error['ps'] & delta['ze']) |
-                                  (error['pb'] & delta['ze']) |
-                                  (error['pb'] & delta['ns'])),
-                      consequent=output['ps'], label='rule ps')
+        rule3 = ctrl.Rule(antecedent=((error['ns'] & delta['pb']) |
+                                      (error['ze'] & delta['pb']) |
+                                      (error['ze'] & delta['ps']) |
+                                      (error['ps'] & delta['ps']) |
+                                      (error['ps'] & delta['ze']) |
+                                      (error['pb'] & delta['ze']) |
+                                      (error['pb'] & delta['ns'])),
+                          consequent=output['ps'], label='rule ps')
 
-    rule4 = ctrl.Rule(antecedent=((error['ps'] & delta['pb']) |
-                                  (error['pb'] & delta['pb']) |
-                                  (error['pb'] & delta['ps'])),
-                      consequent=output['pb'], label='rule pb')
+        rule4 = ctrl.Rule(antecedent=((error['ps'] & delta['pb']) |
+                                      (error['pb'] & delta['pb']) |
+                                      (error['pb'] & delta['ps'])),
+                          consequent=output['pb'], label='rule pb')
 
-    system = ctrl.ControlSystem(rules=[rule0, rule1, rule2, rule3, rule4])
+        system = ctrl.ControlSystem(rules=[rule0, rule1, rule2, rule3, rule4])
 
-    sim = ctrl.ControlSystemSimulation(system, flush_after_run=21 * 21 + 1)
+        sim = ctrl.ControlSystemSimulation(system, flush_after_run=21 * 21 + 1)
 
-    upsampled = np.linspace(-2, 2, 21)
-    x, y = np.meshgrid(upsampled, upsampled)
-    z = np.zeros_like(x)
+        upsampled = np.linspace(-2, 2, 21)
+        x, y = np.meshgrid(upsampled, upsampled)
+        z = np.zeros_like(x)
 
-    # Loop through the system 21*21 times to collect the control surface
-    for i in range(21):
-        for j in range(21):
-            sim.input['error'] = x[i, j]
-            sim.input['delta'] = y[i, j]
-            sim.compute()
-            z[i, j] = sim.output['output']
+        # Loop through the system 21*21 times to collect the control surface
+        for i in range(21):
+            for j in range(21):
+                sim.input['error'] = x[i, j]
+                sim.input['delta'] = y[i, j]
+                sim.compute()
+                z[i, j] = sim.output['output']
 
-    sim.print_state()
+        sim.print_state()
 
-    # Antecedent testing
-    assert 'Antecedents' in mock_stdout.getvalue()
-    assert 'Antecedent: error' in mock_stdout.getvalue()
-    assert 'Antecedent: delta' in mock_stdout.getvalue()
+        # Antecedent testing
+        assert 'Antecedents' in mock_stdout.getvalue()
+        assert 'Antecedent: error' in mock_stdout.getvalue()
+        assert 'Antecedent: delta' in mock_stdout.getvalue()
 
-    # Rules testing
-    assert 'Rules' in mock_stdout.getvalue()
-    assert 'RULE #0:' in mock_stdout.getvalue()
-    assert 'IF ((error[nb] AND delta[nb]) OR (error[ns] AND delta[nb])) ' + \
-           'OR (error[nb] AND delta[ns]) THEN output[nb]' \
-           in mock_stdout.getvalue()
-    assert 'Aggregation (IF-clause):' in mock_stdout.getvalue()
-    assert 'Activation (THEN-clause):' in mock_stdout.getvalue()
-    assert 'RULE #1:' in mock_stdout.getvalue()
-    assert 'RULE #2:' in mock_stdout.getvalue()
-    assert 'RULE #3:' in mock_stdout.getvalue()
-    assert 'RULE #4:' in mock_stdout.getvalue()
+        # Rules testing
+        assert 'Rules' in mock_stdout.getvalue()
+        assert 'RULE #0:' in mock_stdout.getvalue()
+        assert (
+            'IF ((error[nb] AND delta[nb]) OR (error[ns] AND delta[nb])) '
+               'OR (error[nb] AND delta[ns]) THEN output[nb]'
+        ) in mock_stdout.getvalue()
+        assert 'Aggregation (IF-clause):' in mock_stdout.getvalue()
+        assert 'Activation (THEN-clause):' in mock_stdout.getvalue()
+        assert 'RULE #1:' in mock_stdout.getvalue()
+        assert 'RULE #2:' in mock_stdout.getvalue()
+        assert 'RULE #3:' in mock_stdout.getvalue()
+        assert 'RULE #4:' in mock_stdout.getvalue()
 
-    # Intermediaries and Conquests testing
-    assert 'Intermediaries and Conquests' in mock_stdout.getvalue()
-    assert 'Consequent: output' in mock_stdout.getvalue()
-    assert 'Accumulate using accumulation_max' in mock_stdout.getvalue()
+        # Intermediaries and Conquests testing
+        assert 'Intermediaries and Conquests' in mock_stdout.getvalue()
+        assert 'Consequent: output' in mock_stdout.getvalue()
+        assert 'Accumulate using accumulation_max' in mock_stdout.getvalue()
 
-    sim.reset()
+        sim.reset()
 
 
 def test_print_state(print_state=False):

--- a/skfuzzy/control/tests/test_ordereddict.py
+++ b/skfuzzy/control/tests/test_ordereddict.py
@@ -22,6 +22,9 @@ try:
     from numpy.testing.decorators import skipif
 except AttributeError:
     from numpy.testing.dec import skipif
+except ModuleNotFoundError:
+    from numpy.testing import dec
+    skipif = dec.skipif
 from _skipclass import skipclassif
 
 

--- a/skfuzzy/image/tests/test_pad.py
+++ b/skfuzzy/image/tests/test_pad.py
@@ -1,4 +1,4 @@
-"""Tests for the array pading functions.
+"""Tests for the array padding functions.
 
 """
 from __future__ import division, absolute_import, print_function
@@ -13,6 +13,9 @@ try:
     from numpy.testing.decorators import skipif
 except AttributeError:
     from numpy.testing.dec import skipif
+except ModuleNotFoundError:
+    from numpy.testing import dec
+    skipif = dec.skipif
 from _skipclass import skipclassif
 
 from skfuzzy.image import pad


### PR DESCRIPTION
This PR is the same as https://github.com/scikit-fuzzy/scikit-fuzzy/pull/263 and includes following changes to the repo:

- created class LogStateControlSystemSimulation (which logs the state of a ControlSystemSimulation) in skfuzzy/control/controlsystem to (i) solve issues with the function print_state() and (ii) to enable access to the components that are shown when calling print_state() without the need for printing them
- updated function print_state() accordingly
- defined two tests to test print_state() in skfuzzy/control/tests/test_controlsystem.py